### PR TITLE
performance improvement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,11 @@ var ScrollContext = function (_Component) {
             this.checkScroll(nextProps.enable);
         }
     }, {
+        key: 'componentWillUnmount',
+        value: function componentWillUnmount() {
+            this.enableBodyScroll();
+        }
+    }, {
         key: 'render',
         value: function render() {
             var _this2 = this;
@@ -78,8 +83,8 @@ var ScrollContext = function (_Component) {
                         }
                         _this2.disableBodyScroll();
                     },
-                    onMouseOut: function onMouseOut() {
-                        if (typeof enable === 'boolean') {
+                    onMouseOut: function onMouseOut(e) {
+                        if (typeof enable === 'boolean' || e.currentTarget.contains(e.relatedTarget)) {
                             return;
                         }
                         _this2.enableBodyScroll();

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,8 @@ class ScrollContext extends Component {
                     }
                     this.disableBodyScroll();
                 }}
-                onMouseOut={() => {
-                    if (typeof enable === 'boolean') {
+                onMouseOut={(e) => {
+                    if (typeof enable === 'boolean' || e.currentTarget.contains(e.relatedTarget)) {
                         return;
                     }
                     this.enableBodyScroll();


### PR DESCRIPTION
Previously, if moving the mouse within a list of items within a scroll context, enable and disable scroll would be triggered when moving over each one.

This change means that as long as the event target is within the scroll context, there is no need to trigger enableScroll again